### PR TITLE
fix: Disallow thrid-party models in /api/endpoint

### DIFF
--- a/src/app/api/endpoint/[namespace]/[endpoint]/sse/route.ts
+++ b/src/app/api/endpoint/[namespace]/[endpoint]/sse/route.ts
@@ -12,6 +12,13 @@ export const dynamic = "force-dynamic";
 export async function GET(_: Request, context: Args): Promise<Response> {
   const params = await context.params;
 
+  if (
+    params.namespace !== "rigarashi" ||
+    params.endpoint !== "mt5-base-ainu-jey"
+  ) {
+    return new Response("Bad request", { status: 403 });
+  }
+
   const url = new URL(
     `/v2/endpoint/${params.namespace}/${params.endpoint}/sse`,
     BASE_URL,


### PR DESCRIPTION
Closes #46

DRYを破っているがとりあえずこれで
